### PR TITLE
feat/#23 chromatic_auto_deploy workflow 추가

### DIFF
--- a/.github/workflows/chromatic_auto_deploy.yml
+++ b/.github/workflows/chromatic_auto_deploy.yml
@@ -1,4 +1,4 @@
-name: 스토리북 배포
+name: Primitive UI 스토리북 배포
 run-name: ${{ github.actor }}의 스토리북 배포
 on:
   pull_request:
@@ -15,7 +15,7 @@ jobs:
   storybook:
     runs-on: ubuntu-latest
     steps:
-      - name: 리포지토리 체크아웃
+      - name: 레포지토리 체크아웃
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -34,7 +34,7 @@ jobs:
       - name: 의존성 설치
         run: pnpm install
 
-      - name: Chromatic에 배포
+      - name: chromatic에 배포
         id: publish_chromatic
         uses: chromaui/action@v1
         with:
@@ -42,9 +42,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           workingDir: packages/primitive
 
-      - name: PR에 댓글 추가
+      - name: chromatic 배포 URL 댓글 작성
         uses: thollander/actions-comment-pull-request@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          message: "🚀 스토리북이 배포되었습니다: ${{ steps.publish_chromatic.outputs.url }}"
+          message: "🐱 스토리북이 배포되었습니다: ${{ steps.publish_chromatic.outputs.url }} 🐱"

--- a/.github/workflows/chromatic_auto_deploy.yml
+++ b/.github/workflows/chromatic_auto_deploy.yml
@@ -6,6 +6,11 @@ on:
       - develop
     paths:
       - "packages/primitive/components/**/*"
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   storybook:
     runs-on: ubuntu-latest

--- a/.github/workflows/chromatic_auto_deploy.yml
+++ b/.github/workflows/chromatic_auto_deploy.yml
@@ -32,7 +32,7 @@ jobs:
         run: corepack prepare pnpm@latest --activate
 
       - name: 의존성 설치
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
 
       - name: chromatic에 배포
         id: publish_chromatic

--- a/.github/workflows/chromatic_auto_deploy.yml
+++ b/.github/workflows/chromatic_auto_deploy.yml
@@ -1,5 +1,5 @@
 name: Primitive UI 스토리북 배포
-run-name: ${{ github.actor }}의 스토리북 배포
+run-name: ${{ github.actor }}의 Primitive UI 스토리북 배포
 on:
   pull_request:
     branches:

--- a/.github/workflows/chromatic_auto_deploy.yml
+++ b/.github/workflows/chromatic_auto_deploy.yml
@@ -1,0 +1,45 @@
+name: 스토리북 배포
+run-name: ${{ github.actor }}의 스토리북 배포
+on:
+  pull_request:
+    branches:
+      - develop
+    paths:
+      - "packages/primitive/components/**/*"
+jobs:
+  storybook:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 리포지토리 체크아웃
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Node.js 설정
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Corepack 활성화
+        run: corepack enable
+
+      - name: pnpm 설치
+        run: corepack prepare pnpm@latest --activate
+
+      - name: 의존성 설치
+        run: pnpm install
+
+      - name: Chromatic에 배포
+        id: publish_chromatic
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.PRIMITIVE_UI_CHROMATIC_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workingDir: packages/primitive
+
+      - name: PR에 댓글 추가
+        uses: thollander/actions-comment-pull-request@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          message: "🚀 스토리북이 배포되었습니다: ${{ steps.publish_chromatic.outputs.url }}"

--- a/packages/primitive/components/Button.stories.ts
+++ b/packages/primitive/components/Button.stories.ts
@@ -1,23 +1,22 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { fn } from '@storybook/test';
-import { Button } from './Button';
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "./Button";
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 const meta = {
-  title: 'Example/Button',
+  title: "Example/Button",
   component: Button,
   parameters: {
     // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
-    layout: 'centered',
+    layout: "centered",
   },
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
-  tags: ['autodocs'],
+  tags: ["autodocs"],
   // More on argTypes: https://storybook.js.org/docs/api/argtypes
   argTypes: {
-    backgroundColor: { control: 'color' },
+    backgroundColor: { control: "color" },
   },
   // Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
-  args: { onClick: fn() },
+  args: { onClick: () => alert("hello") },
 } satisfies Meta<typeof Button>;
 
 export default meta;
@@ -27,26 +26,26 @@ type Story = StoryObj<typeof meta>;
 export const Primary: Story = {
   args: {
     primary: true,
-    label: 'Button',
+    label: "Button",
   },
 };
 
 export const Secondary: Story = {
   args: {
-    label: 'Button',
+    label: "Button",
   },
 };
 
 export const Large: Story = {
   args: {
-    size: 'large',
-    label: 'Button',
+    size: "large",
+    label: "Button",
   },
 };
 
 export const Small: Story = {
   args: {
-    size: 'small',
-    label: 'Button',
+    size: "small",
+    label: "Button",
   },
 };

--- a/packages/primitive/components/Button.tsx
+++ b/packages/primitive/components/Button.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import './button.css';
+import React from "react";
+import "./button.css";
 
 interface ButtonProps {
   /**
@@ -13,7 +13,7 @@ interface ButtonProps {
   /**
    * How large should the button be?
    */
-  size?: 'small' | 'medium' | 'large';
+  size?: "small" | "medium" | "large";
   /**
    * Button contents
    */
@@ -29,19 +29,23 @@ interface ButtonProps {
  */
 export const Button = ({
   primary = false,
-  size = 'medium',
+  size = "medium",
   backgroundColor,
   label,
   ...props
 }: ButtonProps) => {
-  const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
+  const mode = primary
+    ? "storybook-button--primary"
+    : "storybook-button--secondary";
   return (
     <button
       type="button"
-      className={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
+      className={["storybook-button", `storybook-button--${size}`, mode].join(
+        " "
+      )}
       {...props}
     >
-      {label}
+      {label}x
       <style>{`
         button {
           background-color: ${backgroundColor};

--- a/packages/primitive/components/Header.stories.ts
+++ b/packages/primitive/components/Header.stories.ts
@@ -1,20 +1,19 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { fn } from '@storybook/test';
-import { Header } from './Header';
+import type { Meta, StoryObj } from "@storybook/react";
+import { Header } from "./Header";
 
 const meta = {
-  title: 'Example/Header',
+  title: "Example/Header",
   component: Header,
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
-  tags: ['autodocs'],
+  tags: ["autodocs"],
   parameters: {
     // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
-    layout: 'fullscreen',
+    layout: "fullscreen",
   },
   args: {
-    onLogin: fn(),
-    onLogout: fn(),
-    onCreateAccount: fn(),
+    onLogin: () => alert("Logged in"),
+    onLogout: () => alert("Logged out"),
+    onCreateAccount: () => alert("Account created"),
   },
 } satisfies Meta<typeof Header>;
 
@@ -24,7 +23,7 @@ type Story = StoryObj<typeof meta>;
 export const LoggedIn: Story = {
   args: {
     user: {
-      name: 'Jane Doe',
+      name: "Jane Doe",
     },
   },
 };

--- a/packages/primitive/package.json
+++ b/packages/primitive/package.json
@@ -15,7 +15,6 @@
     "@storybook/blocks": "^8.1.11",
     "@storybook/nextjs": "^8.1.11",
     "@storybook/react": "^8.1.11",
-    "@storybook/test": "^8.1.11",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "chromatic": "^11.5.4",


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

<!-- 가장 먼저 테크 스펙을 세 줄 내외로 정리합니다. 테크 스펙의 제안 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다.

> Bottom Navigation 영역(하단 탭)을 유저가 원하는 순서로 커스텀할 수 있게 합니다. 서버에 순서 정렬 및 저장 API를 요청할 수 없으므로, 순서를 로컬에 저장하고 불러옵니다. -->

`primitive폴더의 components 폴더`에 변경이 있고 **develop** 브랜치에 **pull request**가 열린 경우에 github actions를 통해 배포된 크로마틱 주소를 comment로 남길 수 있게 하였습니다. 

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

pull request에서는 컴포넌트의 코드만을 확인할 수 있습니다. 해당 코드만을 보고 컴포넌트의 기능, 형태를 파악하기 어렵기 때문에 storybook을 통해 시각적인 테스트를 할 수 있어야만 합니다. 

하지만, 매번 코드 리뷰를 위해서 브랜치에 checkout해서 실행을 하는 것은 효용성이 떨어지기 때문에 chromatic을 통해 storybook을 배포할 수 있게 했습니다.
 
chromatic에서 새로 배포하고 확인하는 과정 또한 개발 경험이 낮아진다고 생각해 github actions를 통해 자동화하여 개발자들이 컴포넌트 테스트와 코드 리뷰를 보다 편하게 진행할 수 있도록 하고자 하였습니다. 

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

- primitive폴더의 components가 변경된 브랜치가 develop 브랜치에 pull request를 작성한 경우 comment로 배포된 chromatic 링크를 자동으로 추가할 수 있게 한다. 

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->

모든 pull request에 chromatic 배포를 할 필요가 없을 것 같아 primitive폴더의 components가 변경된 경우에만 실행되도록 하였습니다.

#### 관련 이슈 

- resolved #23 