### PR TITLE
chore/#30 devDependencies를 워크스페이스 레벨로 이동

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   "devDependencies": {
     "prettier": "^3.2.5",
     "turbo": "^2.0.4",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "@types/node": "^20.14.9",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0"
   },
   "packageManager": "pnpm@8.15.6",
   "engines": {

--- a/packages/plugins/boilerplate/package.json
+++ b/packages/plugins/boilerplate/package.json
@@ -1,52 +1,48 @@
 {
-	"name": "warrr",
-	"version": "0.0.1",
-	"description": "figma plugin react boilerplate",
-	"main": "dist/code.js",
-	"scripts": {
-		"build": "tsc -p tsconfig.json && vite build",
-		"dev": "pnpm run build --watch --mode=development"
-	},
-	"author": "",
-	"license": "",
-	"devDependencies": {
-		"@figma/eslint-plugin-figma-plugins": "*",
-		"@figma/plugin-typings": "*",
-		"@types/node": "^20.14.9",
-		"@types/react": "^18.3.3",
-		"@types/react-dom": "^18.3.0",
-		"@typescript-eslint/eslint-plugin": "^6.12.0",
-		"@typescript-eslint/parser": "^6.12.0",
-		"@vitejs/plugin-react": "^4.3.1",
-		"eslint": "^8.54.0",
-		"typescript": "^5.3.2",
-		"vite": "^5.3.1",
-		"vite-plugin-generate-file": "^0.1.1"
-	},
-	"eslintConfig": {
-		"extends": [
-			"eslint:recommended",
-			"plugin:@typescript-eslint/recommended",
-			"plugin:@figma/figma-plugins/recommended"
-		],
-		"parser": "@typescript-eslint/parser",
-		"parserOptions": {
-			"project": "./tsconfig.json"
-		},
-		"root": true,
-		"rules": {
-			"@typescript-eslint/no-unused-vars": [
-				"error",
-				{
-					"argsIgnorePattern": "^_",
-					"varsIgnorePattern": "^_",
-					"caughtErrorsIgnorePattern": "^_"
-				}
-			]
-		}
-	},
-	"dependencies": {
-		"react": "^18.3.1",
-		"react-dom": "^18.3.1"
-	}
+  "name": "warrr",
+  "version": "0.0.1",
+  "description": "figma plugin react boilerplate",
+  "main": "dist/code.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json && vite build",
+    "dev": "pnpm run build --watch --mode=development"
+  },
+  "author": "",
+  "license": "",
+  "devDependencies": {
+    "@figma/eslint-plugin-figma-plugins": "*",
+    "@figma/plugin-typings": "*",
+    "@typescript-eslint/eslint-plugin": "^6.12.0",
+    "@typescript-eslint/parser": "^6.12.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "eslint": "^8.54.0",
+    "vite": "^5.3.1",
+    "vite-plugin-generate-file": "^0.1.1"
+  },
+  "eslintConfig": {
+    "extends": [
+      "eslint:recommended",
+      "plugin:@typescript-eslint/recommended",
+      "plugin:@figma/figma-plugins/recommended"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+      "project": "./tsconfig.json"
+    },
+    "root": true,
+    "rules": {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_",
+          "caughtErrorsIgnorePattern": "^_"
+        }
+      ]
+    }
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  }
 }

--- a/packages/primitive/package.json
+++ b/packages/primitive/package.json
@@ -15,11 +15,8 @@
     "@storybook/blocks": "^8.1.11",
     "@storybook/nextjs": "^8.1.11",
     "@storybook/react": "^8.1.11",
-    "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0",
     "chromatic": "^11.5.4",
-    "storybook": "^8.1.11",
-    "typescript": "^5.4.5"
+    "storybook": "^8.1.11"
   },
   "dependencies": {
     "next": "^14.2.4",


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

<!-- 가장 먼저 테크 스펙을 세 줄 내외로 정리합니다. 테크 스펙의 제안 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다.

> Bottom Navigation 영역(하단 탭)을 유저가 원하는 순서로 커스텀할 수 있게 합니다. 서버에 순서 정렬 및 저장 API를 요청할 수 없으므로, 순서를 로컬에 저장하고 불러옵니다. -->

devDependencies를 공통적으로 관리하고자 워크스페이스 레벨로 이동하였습니다. 

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

각 패키지별로 devDependencies를 관리하게 되면 버전관리가 어렵고, 관리해야 하는 의존성의 바운더리가 커지는 문제가 생길 수 있습니다. 따라서, 공통적으로 처리할 수 있는 devDependencies를 워크스페이스 레벨로 이동하여 관리한다면 해당 문제를 해결하고자 합니다.

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

- 패키지 단위에서 관리하던 devDependencies를 워크스페이스 레벨로 올린다. 

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->

eslint나 prettier도 추가되면 워크스페이스에서 버전은 통합관리하고 각 패키지에서 config을 통해 커스텀하여 사용하는 방식이 좋을 것 같습니다. 

Discussions에서 의존성에 대해 개선할 수 있는 방법있으면 공유해서 추가 개선하면 좋을 것 같습니다. 
#29 

#### 관련 이슈 

- resolved #30 