### PR TITLE
feat/#51 공통 prettier 설정 불러오도록 설정 변경

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,6 @@
     "source.fixAll.eslint": "explicit",
     "source.organizeImports": "explicit"
   },
+  "prettier.requireConfig": true,
   "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
### **요약 (Summary)**

로컬 prettier 설정이 아닌, 와르르르의 공통 prettier 설정을 불러오도록 설정을 변경합니다.

### **배경 (Background)**

개개인마다 로컬에 설정되어 있는 prettier 설정이 다릅니다.
일관적으로 코드를 작성하기 위해서 와르르르에서 정의한 prettier 설정 파일을 불러올 수 있도록 설정을 추가합니다.

### **목표 (Goals)**

vscode 설정에 공통 prettier 설정 불러오도록 설정 변경

### **이외 고려 사항들 (Other Considerations)**

현재 루트에 있는 prettier 설정 대신 제 로컬에 있는 prettier 설정을 가져와서 "prettier.requireConfig": true 설정 추가해뒀습니다.
해당 설정은 prettier 관련 설정을 필수적으로 요구하고, 만약 없다면 포맷팅하지 않는다고 합니다.
포맷팅 시 루트에 있는 prettier 설정을 가져와서 사용한다고 합니다.

#### 관련 이슈

- resolved #51 
