### PR TITLE
chore/#46 D-day Labeler workflow 추가

### DIFF
--- a/.github/workflows/pr-dday-labeler.yml
+++ b/.github/workflows/pr-dday-labeler.yml
@@ -1,0 +1,22 @@
+name: PR D-day Labeler
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  pull_request:
+    types: [opened, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR D-day Labeler
+        uses: minai621/pr-dday-labeler@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/pr-dday-labeler.yml
+++ b/.github/workflows/pr-dday-labeler.yml
@@ -2,7 +2,7 @@ name: PR D-day Labeler
 
 on:
   schedule:
-    - cron: "0 3 * * *"
+    - cron: "0 15 * * *"
   pull_request:
     types: [opened, reopened]
   workflow_dispatch:

--- a/.github/workflows/pr-dday-labeler.yml
+++ b/.github/workflows/pr-dday-labeler.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PR D-day Labeler
-        uses: team-warrr/pr-dday-labeler@main
+        uses: team-warrr/pr-dday-labeler@1.0.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/pr-dday-labeler.yml
+++ b/.github/workflows/pr-dday-labeler.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PR D-day Labeler
-        uses: minai621/pr-dday-labeler@main
+        uses: team-warrr/pr-dday-labeler@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

<!-- 가장 먼저 테크 스펙을 세 줄 내외로 정리합니다. 테크 스펙의 제안 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다.

> Bottom Navigation 영역(하단 탭)을 유저가 원하는 순서로 커스텀할 수 있게 합니다. 서버에 순서 정렬 및 저장 API를 요청할 수 없으므로, 순서를 로컬에 저장하고 불러옵니다. -->

GitHub Actions를 사용하여 PR의 D-day 레이블을 매일 12시에 자동으로 업데이트합니다. 레이블은 D-3부터 시작하여 D-0까지 변경되며, 변경 시 Slack으로 알림을 보냅니다. 이를 통해 PR의 마감 기한을 시각적으로 표시하고 팀원들에게 적시에 알림을 제공합니다.

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

PR(Pull Request) 관리는 개발 프로세스에서 중요한 부분입니다. 하지만 PR의 리뷰 기한을 놓치거나 잊어버리는 경우가 종종 발생합니다. 이로 인해 코드 병합이 지연되고 전체 개발 일정에 영향을 줄 수 있습니다.
이 문제를 해결하기 위해 PR에 자동으로 D-day 레이블을 부여하고 매일 업데이트하는 시스템이 필요합니다. 또한, Slack 알림을 통해 팀원들에게 PR의 상태를 주기적으로 알려줌으로써 적시에 리뷰를 진행할 수 있도록 합니다.

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

- PR 생성 시 자동으로 D-3 레이블을 부여합니다.
![image](https://github.com/user-attachments/assets/1268ce24-12d4-4143-913a-f074a364671a)
- 매일 12시에 D-day 레이블을 자동으로 업데이트합니다 (D-3 → D-2 → D-1 → D-0).
- 레이블 업데이트 시 Slack으로 알림을 보냅니다.
- PR 마감일(D-0)에 추가적인 강조 알림을 제공합니다.
- 시스템 구현을 통해 PR 리뷰 프로세스의 효율성을 높이고 팀의 생산성을 향상시킵니다.


### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->

해당 액션을 구현하기 위해서 따로 액션 스크립트를 가진 레포지토리를 만들었습니다. (액션 가독성을 위해서, 관리를 위해서도 배포하는게 좋다고 생각했습니다)
packages에 만들까 했는데, 레포지토리에 굳이 포함되지 않아도 되는 패키지라고 생각해서 [레포지토리 링크](https://github.com/minai621/pr-dday-labeler), 일단은 개인 레포지토리에 옮겨두었는데요. 
모두가 허용하는 변경이라면, team-warrr 조직에 레포지토리 이전하는 것도 괜찮을 것 같은데 다들 어떻게 생각하시는지 궁금합니다. 


#### 관련 이슈

- resolved #46 
