### PR TITLE
chore/#93 husky 오류 해결

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,9 +1,6 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 pnpm lint
 
-pnpm test
+pnpm jest --passWithNoTests
 if [ $? -ne 0 ]; then
   echo "테스트 실패"
   exit 1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,6 @@
 pnpm lint
 
-pnpm jest --passWithNoTests
+pnpm test
 if [ $? -ne 0 ]; then
   echo "테스트 실패"
   exit 1

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 pnpm format

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,7 +3,7 @@ import type { Config } from "jest";
 const config: Config = {
   testEnvironment: "jsdom",
   preset: "ts-jest",
-  testMatch: ["<rootDir>/packages/**/?(*.)+(spec|test).[jt]s?(x)"],
+  testMatch: ["<rootDir>/packages/**/__tests__/**/*.(spec|test).[jt]s?(x)"],
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
 };
 


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

<!-- 가장 먼저 테크 스펙을 세 줄 내외로 정리합니다. 테크 스펙의 제안 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다.

> Bottom Navigation 영역(하단 탭)을 유저가 원하는 순서로 커스텀할 수 있게 합니다. 서버에 순서 정렬 및 저장 API를 요청할 수 없으므로, 순서를 로컬에 저장하고 불러옵니다. -->
husky의 pre-commit에서 문제가 발생하여 해결하였습니다.

### **배경**
[husky의 release 노트](https://github.com/typicode/husky/releases/tag/v9.0.1)에 따르면 버전이 9.0.1 이상으로 올라가면서 다음과 같이 변경해야 한다고 합니다.
![image](https://github.com/user-attachments/assets/d3afdddc-8ba7-4971-a984-80911d01a68b)
해당 코드는 8 버전에서 필수적인 코드였으나 9버전으로 업데이트되면서 불필요해진 코드로 다른 팀원들 기기에서는 정상동작하였으나 제 기기에서는 9버전과의 충돌을 일으킨 것 같습니다.


또한, jest의 설정이 실제 테스트 파일이 존재하는 위치를 찾지 못해 
```
No tests found, exiting with code 1
```
에러가 발생하고 있었습니다. 
따라서, testMatch를 수정하여 제대로 테스트 파일의 위치를 찾을 수 있도록 하였습니다.
다만, 이 부분은 기존 코드가 다른 기기에서는 정상동작했던 것을 고려하여 각자의 기기에서 해당 test match가 jest의 test 범위를 제대로 잡는지 확인해주셔야 합니다.
@minai621 @ghdtjgus76 @gs0428 

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->
- commit을 찍을 때 정상적으로 lint와 test 검사를 실행합니다.
- ⭐이상이 없는 경우 commit을 막지 않습니다.⭐
- jest의 test match가 제대로 테스트 파일을 파악합니다.


#### 관련 이슈

- resolved #93 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
	- Husky의 pre-commit 및 pre-push 훅을 간소화하여 lint 및 format 명령어 실행 방식에 영향을 미칠 수 있습니다.

- **구성 변경**
	- Jest 구성에서 테스트 파일 검색 범위를 `__tests__` 하위 디렉토리로 제한하여 테스트 파일 관리가 용이해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->